### PR TITLE
Improve `type="checkbox"` tests and guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ version links.
 
 ## master
 
+Improve test coverage and README.md explanations of the `check` and `uncheck`
+form-filling helper methods.
+
 ## [0.2.0] - April 12, 2020
 
 While `with_form` can simplify `<form>` element interactions with multiple

--- a/db/migrate/20200310042146_create_widget_records.rb
+++ b/db/migrate/20200310042146_create_widget_records.rb
@@ -1,4 +1,4 @@
-class CreateWidgetRecords < ActiveRecord::Migration[Rails.version.to_f]
+class CreateWidgetRecords < ActiveRecord::Migration[5.2]
   def change
     create_table :widget_records do |t|
       t.text :text_field

--- a/db/migrate/20200417133424_add_boolean_check_box_field_to_widget_records.rb
+++ b/db/migrate/20200417133424_add_boolean_check_box_field_to_widget_records.rb
@@ -1,0 +1,7 @@
+class AddBooleanCheckBoxFieldToWidgetRecords < ActiveRecord::Migration[5.2]
+  def change
+    change_table :widget_records do |t|
+      t.boolean :boolean_check_box_field
+    end
+  end
+end

--- a/lib/with_form/model_form.rb
+++ b/lib/with_form/model_form.rb
@@ -45,7 +45,14 @@ module WithForm
     def check(attribute, **options)
       case attribute
       when Symbol
-        values = Array(@model.public_send(attribute))
+        attribute_value = @model.public_send(attribute)
+
+        case attribute_value
+        when TrueClass, FalseClass, NilClass
+          values = Array(attribute)
+        else
+          values = Array(attribute_value)
+        end
       else
         values = Array(attribute)
       end
@@ -56,7 +63,14 @@ module WithForm
     def uncheck(attribute, **options)
       case attribute
       when Symbol
-        values = Array(@model.public_send(attribute))
+        attribute_value = @model.public_send(attribute)
+
+        case attribute_value
+        when TrueClass, FalseClass, NilClass
+          values = Array(attribute)
+        else
+          values = Array(attribute_value)
+        end
       else
         values = Array(attribute)
       end

--- a/lib/with_form/model_form.rb
+++ b/lib/with_form/model_form.rb
@@ -32,9 +32,8 @@ module WithForm
     end
 
     def choose(attribute, **options)
-      case attribute
-      when Symbol
-        value = @model.public_send(attribute)
+      if attribute.kind_of? Symbol
+        value = read_attribute(attribute)
       else
         value = attribute
       end
@@ -43,45 +42,28 @@ module WithForm
     end
 
     def check(attribute, **options)
-      case attribute
-      when Symbol
-        attribute_value = @model.public_send(attribute)
-
-        case attribute_value
-        when TrueClass, FalseClass, NilClass
-          values = Array(attribute)
-        else
-          values = Array(attribute_value)
-        end
+      if attribute.kind_of? Symbol
+        value = read_attribute(attribute)
       else
-        values = Array(attribute)
+        value = attribute
       end
 
-      values.each { |value| scope_form.check(value, **options) }
+      Array(value).each { |value| scope_form.check(value, **options) }
     end
 
     def uncheck(attribute, **options)
-      case attribute
-      when Symbol
-        attribute_value = @model.public_send(attribute)
-
-        case attribute_value
-        when TrueClass, FalseClass, NilClass
-          values = Array(attribute)
-        else
-          values = Array(attribute_value)
-        end
+      if attribute.kind_of? Symbol
+        value = read_attribute(attribute)
       else
-        values = Array(attribute)
+        value = attribute
       end
 
-      values.each { |value| scope_form.uncheck(value, **options) }
+      Array(value).each { |value| scope_form.uncheck(value, **options) }
     end
 
     def select(attribute, from: nil, **options)
-      case attribute
-      when Symbol
-        value = @model.public_send(attribute)
+      if attribute.kind_of? Symbol
+        value = read_attribute(attribute)
       else
         value = attribute
       end
@@ -90,9 +72,8 @@ module WithForm
     end
 
     def unselect(attribute, from: nil, **options)
-      case attribute
-      when Symbol
-        value = @model.public_send(attribute)
+      if attribute.kind_of? Symbol
+        value = read_attribute(attribute)
       else
         value = attribute
       end
@@ -115,6 +96,16 @@ module WithForm
 
     def scope_form
       WithForm::ScopeForm.new(scope: @model.model_name.i18n_key, page: @page)
+    end
+
+    def read_attribute(attribute)
+      attribute_value = @model.public_send(attribute)
+
+      if attribute_value.in?([true, false, nil])
+        attribute
+      else
+        attribute_value
+      end
     end
   end
 end

--- a/test/dummy/app/views/widget_records/new.html.erb
+++ b/test/dummy/app/views/widget_records/new.html.erb
@@ -4,6 +4,9 @@
   <%= form.label(:text_field) %>
   <%= form.text_field(:text_field) %>
 
+  <%= form.label(:boolean_check_box_field) %>
+  <%= form.check_box(:boolean_check_box_field) %>
+
   <%= form.submit %>
   <%= form.submit translate("helpers.submit.widget_record.submit")%>
 <% end %>

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
   helpers:
     label:
       widget_record:
+        boolean_check_box_field: "Record Boolean Check Box Field"
         text_field: "Record Text Field"
       widget:
         checkbox_field: "Checkbox Field"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_12_144214) do
+ActiveRecord::Schema.define(version: 2020_04_17_133424) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_04_12_144214) do
 
   create_table "widget_records", force: :cascade do |t|
     t.text "text_field"
+    t.boolean "boolean_check_box_field"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/system/check_test.rb
+++ b/test/system/check_test.rb
@@ -44,3 +44,38 @@ class CheckTest < ApplicationSystemTestCase
     assert_checked_field "Ruby"
   end
 end
+
+class RecordCheckTest < ApplicationSystemTestCase
+  test "check with nil value and Symbol argument" do
+    widget_record = WidgetRecord.new(boolean_check_box_field: nil)
+    visit new_widget_record_path
+
+    with_form(model: widget_record) do |form|
+      form.check :boolean_check_box_field
+    end
+
+    assert_checked_field translate("helpers.label.widget_record.boolean_check_box_field")
+  end
+
+  test "check with true value and Symbol argument" do
+    widget_record = WidgetRecord.new(boolean_check_box_field: true)
+    visit new_widget_record_path
+
+    with_form(model: widget_record) do |form|
+      form.check :boolean_check_box_field
+    end
+
+    assert_checked_field translate("helpers.label.widget_record.boolean_check_box_field")
+  end
+
+  test "check with false value and Symbol argument" do
+    widget_record = WidgetRecord.new(boolean_check_box_field: false)
+    visit new_widget_record_path
+
+    with_form(model: widget_record) do |form|
+      form.check :boolean_check_box_field
+    end
+
+    assert_checked_field translate("helpers.label.widget_record.boolean_check_box_field")
+  end
+end

--- a/test/system/uncheck_test.rb
+++ b/test/system/uncheck_test.rb
@@ -43,3 +43,38 @@ class UncheckTest < ApplicationSystemTestCase
     assert_no_checked_field "Java"
   end
 end
+
+class ModelUncheckTest < ApplicationSystemTestCase
+  test "uncheck with nil value and Symbol argument" do
+    widget_record = WidgetRecord.new(boolean_check_box_field: nil)
+    visit new_widget_record_path
+
+    with_form(model: widget_record) do |form|
+      form.uncheck :boolean_check_box_field
+    end
+
+    assert_unchecked_field translate("helpers.label.widget_record.boolean_check_box_field")
+  end
+
+  test "uncheck with true value and Symbol argument" do
+    widget_record = WidgetRecord.new(boolean_check_box_field: true)
+    visit new_widget_record_path
+
+    with_form(model: widget_record) do |form|
+      form.uncheck :boolean_check_box_field
+    end
+
+    assert_unchecked_field translate("helpers.label.widget_record.boolean_check_box_field")
+  end
+
+  test "uncheck with false value and Symbol argument" do
+    widget_record = WidgetRecord.new(boolean_check_box_field: false)
+    visit new_widget_record_path
+
+    with_form(model: widget_record) do |form|
+      form.uncheck :boolean_check_box_field
+    end
+
+    assert_unchecked_field translate("helpers.label.widget_record.boolean_check_box_field")
+  end
+end


### PR DESCRIPTION
This commit improves support for `check` and `uncheck` calls to
`with_form(model:)` invocations that are passed `ActiveRecord::Base`
instances.

To support this, add migrations to add a `Boolean` column to the
`widget_records` table.

Extract `WithForm::ModelForm#read_attribute`
---

When `with_form(model:)` instances are passed a [`Symbol`][ruby-symbol],
they delegate a method with a matching name to their underlying models,
and pass the value that's returned along to a `WithForm::ScopeForm`
instance.

There was structural and conceptual duplication of that guarding and
reading logic spread across several method implementations.

This commit extracts that to a private `read_attribute` method, and
re-structures the call sites.

[ruby-symbol]: https://ruby-doc.org/core-2.7.1/Symbol.html